### PR TITLE
fixed null pointer exception in copied LabelCombiationExtended

### DIFF
--- a/mlc_pcc/src/put/mlc/classifiers/pcc/inference/common/LabelCombinationExtended.java
+++ b/mlc_pcc/src/put/mlc/classifiers/pcc/inference/common/LabelCombinationExtended.java
@@ -46,7 +46,6 @@ public class LabelCombinationExtended extends LabelCombination {
 		this.labels = new double[this.numLabels];
 		this.inference = inference;
 		this.instance = (Instance) instance.copy();
-		this.inference = copy.inference;
 	}
 
 	public void copy(LabelCombinationExtended copy) {
@@ -54,6 +53,7 @@ public class LabelCombinationExtended extends LabelCombination {
 		this.numLabels = copy.numLabels;
 		this.state = copy.state;
 		this.instance = (Instance) copy.getInstance().copy();
+		this.inference = copy.inference;
 	}
 
 	public void setNextLabel(int prediction, double p) {

--- a/mlc_pcc/src/put/mlc/classifiers/pcc/inference/common/LabelCombinationExtended.java
+++ b/mlc_pcc/src/put/mlc/classifiers/pcc/inference/common/LabelCombinationExtended.java
@@ -46,6 +46,7 @@ public class LabelCombinationExtended extends LabelCombination {
 		this.labels = new double[this.numLabels];
 		this.inference = inference;
 		this.instance = (Instance) instance.copy();
+		this.inference = copy.inference;
 	}
 
 	public void copy(LabelCombinationExtended copy) {


### PR DESCRIPTION
that occurs when the inference reference of the copy is accessed. (as the inference has previously not been copied)

closes #2 